### PR TITLE
fix: Component discovery config was missing glob pattern

### DIFF
--- a/wcs.config.js
+++ b/wcs.config.js
@@ -10,7 +10,7 @@ module.exports = {
    * Refer to https://component-studio.wixanswers.com/en/article/kb17226 for more information.
    */
   componentsDiscovery: {
-    include: ["./src/components"],
+    include: ["./src/components/**"],
     exclude: ["./src/component-templates/"],
   },
 


### PR DESCRIPTION
Previous configuration caused the product to say that no components were found in the scan.